### PR TITLE
XIVY-3442 fix: table not using full space after adding column

### DIFF
--- a/rule-beans/src/com/axonivy/ivy/process/element/rule/ui/DecisionTableEditor.java
+++ b/rule-beans/src/com/axonivy/ivy/process/element/rule/ui/DecisionTableEditor.java
@@ -147,6 +147,7 @@ public class DecisionTableEditor extends Composite
           ColumnType type = getTypeOf(attribute);
           table.addConditionColumn(new ConditionColumn(attribute, type));
           table.pack(true);
+          table.getParent().layout(true);
         }
       }
     });
@@ -162,6 +163,7 @@ public class DecisionTableEditor extends Composite
           ColumnType type = getTypeOf(attribute);
           table.addActionColumn(new ActionColumn(attribute, type));
           table.pack(true);
+          table.getParent().layout(true);
         }
       }
     });


### PR DESCRIPTION
- decision table collapsed to tiny it's most tiny representation after
adding a condition/or output column
- fix: layout parent composite to enforce re-drawing of the table.

BUILD: https://jenkins.ivyteam.io/job/supplements-bpm-beans/job/bugfix%252FXIVY-3442-decisionTableSize/